### PR TITLE
Fix for missing varname

### DIFF
--- a/x86_info_term.py
+++ b/x86_info_term.py
@@ -229,27 +229,32 @@ def parse_intrinsics_guide(path):
 
     table = []
     for i, intrinsic in enumerate(root.findall('intrinsic')):
-        tech = intrinsic.attrib['tech']
-        name = intrinsic.attrib['name']
-        desc = [d.text for d in intrinsic.findall('description')][0]
-        insts = [(inst.attrib['name'].lower(), inst.attrib.get('form', ''))
-                for inst in intrinsic.findall('instruction')]
-        # Return type spec changed in XML as of 3.5.0
-        return_type = (intrinsic.attrib['rettype'] if version < (3, 5, 0) else
-                [r.attrib['type'] for r in intrinsic.findall('return')][0])
-        key = '%s %s %s %s' % (tech, name, desc, insts)
-        table.append({
-            'id': i,
-            'tech': tech,
-            'name': name,
-            'params': [(p.attrib['varname'], p.attrib['type'])
-                for p in intrinsic.findall('parameter')],
-            'return_type': return_type,
-            'desc': desc,
-            'operations': [op.text for op in intrinsic.findall('operation')],
-            'insts': insts,
-            'search-key': key.lower(),
-        })
+        try:
+            tech = intrinsic.attrib['tech']
+            name = intrinsic.attrib['name']
+            desc = [d.text for d in intrinsic.findall('description')][0]
+            insts = [(inst.attrib['name'].lower(), inst.attrib.get('form', ''))
+                    for inst in intrinsic.findall('instruction')]
+            # Return type spec changed in XML as of 3.5.0
+            return_type = (intrinsic.attrib['rettype'] if version < (3, 5, 0) else
+                    [r.attrib['type'] for r in intrinsic.findall('return')][0])
+            key = '%s %s %s %s' % (tech, name, desc, insts)
+            table.append({
+                'id': i,
+                'tech': tech,
+                'name': name,
+                'params': [(p.attrib.get('varname',''), p.attrib['type'])
+                    for p in intrinsic.findall('parameter')],
+                'return_type': return_type,
+                'desc': desc,
+                'operations': [op.text for op in intrinsic.findall('operation')],
+                'insts': insts,
+                'search-key': key.lower(),
+            })
+        except:
+            print('Error while parsing ', name, '\nContents:\n', ET.tostring(intrinsic, encoding='unicode'))
+            raise
+        
     return [version, table]
 
 def get_intr_info_table(intr):

--- a/x86_info_term.py
+++ b/x86_info_term.py
@@ -805,14 +805,17 @@ def download_data(args):
 
     for dataset in DATASETS:
         # Download file
-        url = '%s/%s' % (dataset.base_url, dataset.path)
-        print('Downloading %s...' % url)
-        with urllib.request.urlopen(url) as f:
-            data = f.read()
+        if (os.path.exists(dataset.full_path)):
+            print(dataset.path, 'already exists, skipping download...')
+        else:
+            url = '%s/%s' % (dataset.base_url, dataset.path)
+            print('Downloading %s...' % url)
+            with urllib.request.urlopen(url) as f:
+                data = f.read()
 
-        # Write output file
-        with open(dataset.full_path, 'wb') as f:
-            f.write(data)
+            # Write output file
+            with open(dataset.full_path, 'wb') as f:
+                f.write(data)
 
 # We store preprocessed data from the XML to have a faster startup time.
 # The schema of the preprocessed data might change in the future, in


### PR DESCRIPTION
When I run this today, I get a failure to build cache, because some stuff like `vzeroall` has no paramname (the parameter is `void`).