### PR TITLE
Fixed bad data_dir when executing via a symlink

### DIFF
--- a/x86_info_term.py
+++ b/x86_info_term.py
@@ -1264,7 +1264,7 @@ def get_info(args):
     return cache
 
 def get_cache():
-    base_dir = os.path.abspath(os.path.dirname(sys.argv[0]))
+    base_dir = os.path.dirname(os.path.realname(sys.argv[0]))
     data_dir = '%s/data' % base_dir
 
     # Command line parsing


### PR DESCRIPTION
Previously the script couldn't find correct path for the data_dir
variable, if the script was launched via a symlink.