### PR TITLE
Fixed unknown attribute `realname`

### DIFF
--- a/x86_info_term.py
+++ b/x86_info_term.py
@@ -1264,7 +1264,7 @@ def get_info(args):
     return cache
 
 def get_cache():
-    base_dir = os.path.dirname(os.path.realname(sys.argv[0]))
+    base_dir = os.path.dirname(os.path.realpath(sys.argv[0]))
     data_dir = '%s/data' % base_dir
 
     # Command line parsing


### PR DESCRIPTION
When trying to launch `x86_info_term`, I get the following error: `AttributeError: module 'posixpath' has no attribute 'realname'`.
I don't see any reference to the method `realname` in the `os.path` [documentation](https://docs.python.org/3/library/os.path.html).

This pull request only replace `realname` by `abspath`.