### PR TITLE
Set a generic user agent for Intel Intrinsic Guide data

### DIFF
--- a/x86_info_term.py
+++ b/x86_info_term.py
@@ -1242,7 +1242,8 @@ def download_data(args):
             # Download file
             url = '%s/%s' % (dataset.base_url, dataset.path)
             print('Downloading %s...' % url)
-            with urllib.request.urlopen(url) as f:
+            req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+            with urllib.request.urlopen(req) as f:
                 data = f.read()
 
             # Write output file


### PR DESCRIPTION
First of all, thank you very much for developing this utility!

The Intel site recently started to silently refuse the urllib user agent, and the xml file download will never been finished:
```python3
>>> import urllib.request
>>> url = 'https://software.intel.com/content/dam/develop/public/us/en/include/intrinsics-guide/data-latest.xml'
>>> urllib.request.urlopen(url, timeout=5).reason
Traceback (most recent call last):
...
socket.timeout: The read operation timed out
```

This pull request sets a generic user agent (`Mozilla/5.0`) as a workaround:
```python3
>>> req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
>>> urllib.request.urlopen(req, timeout=5).reason
OK
```